### PR TITLE
Full repository name and switch to latest tag

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -11,7 +11,7 @@ image:
   repository: mcmull27/blinky
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "arm"
+  tag: "latest"
 
 imagePullSecrets:
 - name: regcred

--- a/values.yaml
+++ b/values.yaml
@@ -8,7 +8,7 @@ env:
 replicaCount: 1
 
 image:
-  repository: mcmull27/blinky
+  repository: docker.io/mcmull27/blinky
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"


### PR DESCRIPTION
Certain high-level container runtimes like cri-o (Openshift, underlying podman and otherwise available on the prestigious Odroid-C4 cluster of your's truly) have moved away from out-of-the-box support for short names with respect to image repos. This really only impacts docker hub images since those are the only ones you've been able to use the short name for it seems, so this just future-proofs the format. 

Also, multiarch builds of the extremely useful [blinky](https://github.com/mbmcmullen27/blinky) tool are available and I have tested that using the tag of "latest" successfully runs blinky on both arm64 and amd64 platforms.